### PR TITLE
Issue 16 Allow output of cdbcli commands to be piped to shell commands

### DIFF
--- a/cdbcli/commands.py
+++ b/cdbcli/commands.py
@@ -53,6 +53,10 @@ def is_view(doc):
     return doc.startswith('_design/')
 
 
+def json_dumps(json_object):
+    return json.dumps(json_object, sort_keys=True, indent=4)
+
+
 @command_handler('ls')
 def ls(environment, couch_server, variables):
     """ls
@@ -98,7 +102,7 @@ def info(environment, couch_server, variables):
     Show the information of the current database.
     """
     info = environment.current_db.info()
-    environment.output(info, highlighters.json)
+    environment.output(json_dumps(info), highlighters.json)
 
 
 @command_handler('cat', '(?P<doc_id>[^\s]+)')
@@ -116,7 +120,7 @@ def cat(environment, couch_server, variables):
     if not doc:
         raise RuntimeError('Document not found')
 
-    environment.output(doc, highlighters.json)
+    environment.output(json_dumps(doc), highlighters.json)
 
 
 @command_handler('rm', '(?P<doc_id>[^\s]+)')
@@ -155,7 +159,7 @@ def exec_(environment, couch_server, variables):
 
     try:
         for result in environment.current_db.view('{}/_view/{}'.format(view_id, view_name)):
-            environment.output(dict(result.items()), highlighters.json)
+            environment.output(json_dumps(dict(result.items())), highlighters.json)
     except:
         traceback.print_exc()
         raise RuntimeError('Unable to exec view: {}'.format(view_id))

--- a/cdbcli/environment.py
+++ b/cdbcli/environment.py
@@ -39,7 +39,7 @@ class Environment():
             else:
                 stdin = subprocs[i - 1].stdout
 
-            process = subprocess.Popen(shell_command, stdin=stdin, stdout=stdout)
+            process = subprocess.Popen(shell_command, stdin=stdin, stdout=stdout, stderr=sys.stderr)
             subprocs.append(process)
 
         if subprocs:

--- a/cdbcli/environment.py
+++ b/cdbcli/environment.py
@@ -30,7 +30,7 @@ class Environment():
 
         subprocs = []
         for i, shell_command in enumerate(shell_commands):
-            if i == len(shell_commands) -1:
+            if i == len(shell_commands) - 1:
                 stdout = prev_output_stream
             else:
                 stdout = subprocess.PIPE
@@ -38,18 +38,19 @@ class Environment():
             if i == 0:
                 stdin = subprocess.PIPE
             else:
-                stdin = subprocs[i - 1].stdin
+                stdin = subprocs[i - 1].stdout
 
             process = subprocess.Popen(shlex.split(shell_command),
-                                    stdin=stdin,
-                                    stdout=stdout)
+                                       stdin=stdin,
+                                       stdout=stdout)
             subprocs.append(process)
 
         if subprocs:
             self.output_stream = subprocs[0].stdin
+
         try:
             yield self
             if subprocs:
-                subprocs[-1].communicate()
+                subprocs[0].communicate()
         finally:
             self.output_stream = prev_output_stream

--- a/cdbcli/environment.py
+++ b/cdbcli/environment.py
@@ -1,6 +1,5 @@
 import contextlib
 import io
-import shlex
 import subprocess
 import sys
 
@@ -39,9 +38,7 @@ class Environment():
             else:
                 stdin = subprocs[i - 1].stdout
 
-            process = subprocess.Popen(shlex.split(shell_command),
-                                       stdin=stdin,
-                                       stdout=stdout)
+            process = subprocess.Popen(shell_command, stdin=stdin, stdout=stdout)
             subprocs.append(process)
 
         if subprocs:

--- a/cdbcli/environment.py
+++ b/cdbcli/environment.py
@@ -2,7 +2,7 @@ import sys
 import contextlib
 
 
-class Environment(object):
+class Environment():
     def __init__(self, current_db=None, output_stream=sys.stdout):
         self.current_db = current_db
         self.output_stream = output_stream
@@ -15,15 +15,18 @@ class Environment(object):
         self.output_stream.flush()
 
     def run_in_terminal(self, func, render_cli_done=False):
-        if not self.cli:
-            raise RuntimeError('No cli has been set')
-
+        assert self.cli, 'No CLI has been set'
         return self.cli.run_in_terminal(func, render_cli_done)
-
 
     @contextlib.contextmanager
     def handle_pipes(self, pipes):
         self.pipes = pipes
+
+        subprocesses = []
+        for shell_command in pipes:
+            subprocesses.append(subprocess.run(shlex.split(shell_command),
+                                               stdin=subprocess.PIPE, stdout=subprocess.PIPE))
+
         try:
             yield self
         finally:

--- a/cdbcli/environment.py
+++ b/cdbcli/environment.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import shlex
 import subprocess
 import sys
@@ -11,14 +12,12 @@ class Environment():
         self.cli = None
 
     def output(self, text):
-        if hasattr(self.output_stream, 'buffer'):
-            buffer = self.output_stream.buffer
-        else:
-            buffer = self.output_stream
+        output = "{}\n".format(text)
+        if isinstance(self.output_stream, io.BufferedIOBase):
+            output = bytes(output, encoding='utf-8')
 
-        buffer.write(bytes(text, encoding='utf-8'))
-        buffer.write(bytes('\n', encoding='utf-8'))
-        buffer.flush()
+        self.output_stream.write(output)
+        self.output_stream.flush()
 
     def run_in_terminal(self, func, render_cli_done=False):
         assert self.cli, 'No CLI has been set'

--- a/cdbcli/environment.py
+++ b/cdbcli/environment.py
@@ -11,8 +11,14 @@ class Environment():
         self.cli = None
         self.previous_db = None
 
-    def output(self, text):
-        output = "{}\n".format(text)
+    def output(self, text, highlighter=None):
+        """Send text to the environment's output stream.
+        :param text: the text to output
+        :param highlighter: an optional function to colourize the text
+        """
+        highlighter = highlighter or (lambda x: x)
+        highlighted = highlighter(text)
+        output = "{}\n".format(highlighted)
         if isinstance(self.output_stream, io.BufferedIOBase):
             output = bytes(output, encoding='utf-8')
 

--- a/cdbcli/environment.py
+++ b/cdbcli/environment.py
@@ -1,4 +1,5 @@
 import sys
+import contextlib
 
 
 class Environment(object):
@@ -6,6 +7,7 @@ class Environment(object):
         self.current_db = current_db
         self.output_stream = output_stream
         self.cli = None
+        self.pipes = []
 
     def output(self, text):
         self.output_stream.write(text)
@@ -17,3 +19,12 @@ class Environment(object):
             raise RuntimeError('No cli has been set')
 
         return self.cli.run_in_terminal(func, render_cli_done)
+
+
+    @contextlib.contextmanager
+    def handle_pipes(self, pipes):
+        self.pipes = pipes
+        try:
+            yield self
+        finally:
+            self.pipes = []

--- a/cdbcli/highlighters.py
+++ b/cdbcli/highlighters.py
@@ -1,0 +1,16 @@
+import json as simplejson
+import pygments
+from pygments import lexers, formatters
+
+
+def json(json_object):
+    formatted_json = simplejson.dumps(json_object, sort_keys=True, indent=4)
+    return pygments.highlight(formatted_json, lexers.JsonLexer(), formatters.TerminalFormatter())
+
+
+def javascript(code):
+    return pygments.highlight(code, lexers.JavascriptLexer(), formatters.TerminalFormatter())
+
+
+def python(code):
+    return pygments.highlight(code, lexers.PythonLexer(), formatters.TerminalFormatter())

--- a/cdbcli/highlighters.py
+++ b/cdbcli/highlighters.py
@@ -1,10 +1,8 @@
-import json as simplejson
 import pygments
 from pygments import lexers, formatters
 
 
-def json(json_object):
-    formatted_json = simplejson.dumps(json_object, sort_keys=True, indent=4)
+def json(formatted_json):
     return pygments.highlight(formatted_json, lexers.JsonLexer(), formatters.TerminalFormatter())
 
 

--- a/cdbcli/lexer.py
+++ b/cdbcli/lexer.py
@@ -1,4 +1,3 @@
-import re
 import shlex
 
 from prompt_toolkit.contrib.regular_languages.lexer import GrammarLexer

--- a/cdbcli/lexer.py
+++ b/cdbcli/lexer.py
@@ -1,3 +1,4 @@
+import re
 import shlex
 
 from prompt_toolkit.contrib.regular_languages.lexer import GrammarLexer
@@ -29,8 +30,9 @@ def split_cli_command_and_shell_commands(command_text):
     parts = []
     stack = []
     for token in tokens:
+        # TODO: this is probably not the best way to parse shell commands
         if token != '|':
-            if token == ' ':
+            if re.search(r'\s+', token):
                 # since we split by ' '
                 # any token left in the queue
                 # that's a ' ' should be quoted

--- a/cdbcli/lexer.py
+++ b/cdbcli/lexer.py
@@ -33,13 +33,7 @@ def split_cli_command_and_shell_commands(command_text):
     for token in tokens:
         # TODO: this is probably not the best way to parse shell commands
         if token != '|':
-            if re.search(r'\s+', token):
-                # since we split by ' '
-                # any token left in the queue
-                # that's a ' ' should be quoted
-                stack.append(shlex.quote(token))
-            else:
-                stack.append(token)
+            stack.append(token)
         else:
             parts.append(list(stack))
             stack.clear()

--- a/cdbcli/lexer.py
+++ b/cdbcli/lexer.py
@@ -1,3 +1,5 @@
+import shlex
+
 from prompt_toolkit.contrib.regular_languages.lexer import GrammarLexer
 from prompt_toolkit.layout.lexers import SimpleLexer
 from prompt_toolkit.token import Token
@@ -10,3 +12,40 @@ lexer = GrammarLexer(grammar, lexers={
     'operand': SimpleLexer(Token.Operand),
     'database_name': SimpleLexer(Token.Operand),
 })
+
+def split_cli_command_and_shell_commands(command_text):
+    """Split the command text into cli commands and pipes
+
+    e.g.::
+
+        cat ID | grep text
+
+    ``cat ID`` is a CLI command, which will be matched against the CLI grammar tree
+    ``grep text`` is treated as a SHELL command
+
+    Returns a tuple ``(a, b)`` where ``a`` is the CLI command, and ``b`` is a list of shell commands
+    """
+    tokens = shlex.split(command_text)
+    parts = []
+    stack = []
+    for token in tokens:
+        if token != '|':
+            if token == ' ':
+                # since we split by ' '
+                # any token left in the queue
+                # that's a ' ' should be quoted
+                stack.append(shlex.quote(token))
+            else:
+                stack.append(token)
+        else:
+            parts.append(' '.join(stack))
+            stack.clear()
+
+    if stack:
+        parts.append(' '.join(stack))
+        stack.clear()
+
+    if len(parts) == 1:
+        return parts[0], []
+
+    return parts[0], parts[1:]

--- a/cdbcli/lexer.py
+++ b/cdbcli/lexer.py
@@ -30,16 +30,14 @@ def split_cli_command_and_shell_commands(command_text):
     parts = []
     stack = []
     for token in tokens:
-        # TODO: this is probably not the best way to parse shell commands
         if token != '|':
             stack.append(token)
         else:
-            parts.append(list(stack))
-            stack.clear()
+            parts.append(stack)
+            stack = []
 
     if stack:
-        parts.append(list(stack))
-        stack.clear()
+        parts.append(stack)
 
     if len(parts) == 1:
         return ' '.join(parts[0]), []

--- a/cdbcli/lexer.py
+++ b/cdbcli/lexer.py
@@ -41,14 +41,14 @@ def split_cli_command_and_shell_commands(command_text):
             else:
                 stack.append(token)
         else:
-            parts.append(' '.join(stack))
+            parts.append(list(stack))
             stack.clear()
 
     if stack:
-        parts.append(' '.join(stack))
+        parts.append(list(stack))
         stack.clear()
 
     if len(parts) == 1:
-        return parts[0], []
+        return ' '.join(parts[0]), []
 
-    return parts[0], parts[1:]
+    return ' '.join(parts[0]), parts[1:]

--- a/cdbcli/lexer.py
+++ b/cdbcli/lexer.py
@@ -14,6 +14,7 @@ lexer = GrammarLexer(grammar, lexers={
     'database_name': SimpleLexer(Token.Operand),
 })
 
+
 def split_cli_command_and_shell_commands(command_text):
     """Split the command text into cli commands and pipes
 

--- a/cdbcli/main.py
+++ b/cdbcli/main.py
@@ -6,7 +6,7 @@ from cdbcli import repl
 from prompt_toolkit import prompt
 
 
-class Config(object):
+class Config():
     def __init__(self, host, port, username, password, tls, database):
         self.__host = host
         self.__port = port

--- a/cdbcli/repl.py
+++ b/cdbcli/repl.py
@@ -4,7 +4,7 @@ import couchdb
 
 import prompt_toolkit as pt
 from prompt_toolkit import history, shortcuts
-from .lexer import lexer
+from .lexer import lexer, split_cli_command_and_shell_commands
 from .completer import get_completer
 from .style import style
 from .grammar import grammar
@@ -30,14 +30,16 @@ def eval_(environment, couch_server, command_text):
     if not command_text:
         return
 
-    m = grammar.match_prefix(command_text)
+    cli_command, shell_commands = split_cli_command_and_shell_commands(command_text)
+
+    m = grammar.match_prefix(cli_command)
     if not m:
         raise RuntimeError('Invalid input')
 
     command = m.variables().get('command')
 
     if command not in COMMANDS:
-        raise RuntimeError('{}: command not found'.format(command_text))
+        raise RuntimeError('{}: command not found'.format(cli_command))
 
     handler, _, _ = COMMANDS[command]
     handler(environment=environment, couch_server=couch_server, variables=m.variables())

--- a/cdbcli/repl.py
+++ b/cdbcli/repl.py
@@ -1,6 +1,3 @@
-import functools
-import subprocess
-
 import couchdb
 import prompt_toolkit as pt
 

--- a/cdbcli/repl.py
+++ b/cdbcli/repl.py
@@ -42,9 +42,6 @@ def eval_(environment, couch_server, command_text):
     if command not in COMMANDS:
         raise RuntimeError('{}: command not found'.format(cli_command))
 
-    for shell_command in shell_commands:
-        functools.partial(subprocess.run, shlex.split(shell_command), stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-
     handler, _, _ = COMMANDS[command]
     with environment.handle_pipes(shell_command) as environment:
         handler(environment=environment, couch_server=couch_server, variables=m.variables())

--- a/cdbcli/repl.py
+++ b/cdbcli/repl.py
@@ -43,7 +43,7 @@ def eval_(environment, couch_server, command_text):
         raise RuntimeError('{}: command not found'.format(cli_command))
 
     handler, _, _ = COMMANDS[command]
-    with environment.handle_pipes(shell_command) as environment:
+    with environment.pipe(shell_commands) as environment:
         handler(environment=environment, couch_server=couch_server, variables=m.variables())
 
 

--- a/tests/integration/test_repl.py
+++ b/tests/integration/test_repl.py
@@ -33,7 +33,7 @@ def test_command_alias(environment, couch_server):
     @command_handler('abc', aliases=['duh', 'huh'])
     def abc(environment, couch_server):
         """Blah blah"""
-        environment.output('Done.')
+        pass  # pragma: nocover
 
     assert 'abc' in COMMANDS
     handler = COMMANDS['abc']

--- a/tests/integration/test_repl.py
+++ b/tests/integration/test_repl.py
@@ -15,20 +15,6 @@ def _get_output(environment):
     return environment.output_stream.read()
 
 
-def _get_mock_highlight_json(mocker):
-    mock_highlight = mocker.patch('cdbcli.commands.highlighters.json')
-    mock_highlight.return_value = ''
-    return mock_highlight
-
-
-def _get_highlighted(mock_highlight):
-    args = [
-        c[0][0]
-        for c in mock_highlight.call_args_list
-    ]
-    return args
-
-
 def test_command_alias(environment, couch_server):
     @command_handler('abc', aliases=['duh', 'huh'])
     def abc(environment, couch_server):
@@ -222,9 +208,10 @@ def test_exec_view(environment, couch_server, mocker):
      ]
     db.save(get_user_design_doc())
     environment.current_db = db
-    mock_highlight = _get_mock_highlight_json(mocker)
+    environment.output = Mock()
     eval_(environment, couch_server, 'exec _design/users:by_lastname')
-    highlighted = _get_highlighted(mock_highlight)
+    highlighted = [json.loads(c[0][0]) for c in environment.output.call_args_list]
+
     expected = set(['washington', 'jefferson', 'adams'])
     actual = set([x['key'] for x in highlighted])
     assert expected == actual

--- a/tests/integration/test_repl.py
+++ b/tests/integration/test_repl.py
@@ -367,7 +367,7 @@ def test_pipe_commands_one_pipe(environment, couch_server):
     assert 'william.shatner' in output[1]
 
 
-def test_pip_commands_multiple_pipes(environment, couch_server):
+def test_pipe_commands_multiple_pipes(environment, couch_server):
     db = couch_server.create('test')
     [db.save(get_user_doc(first_name, last_name))
      for first_name, last_name in [('william', 'shakespear'),
@@ -384,3 +384,16 @@ def test_pip_commands_multiple_pipes(environment, couch_server):
         output = f.readlines()
 
     assert {'william', 'bill'} == set(map(str.strip, output))
+
+
+def test_pipe_error(environment, couch_server):
+    db = couch_server.create('test')
+    environment.current_db = db
+    _, file_path = tempfile.mkstemp()
+    with io.open(file_path, 'w') as f:
+        environment.output_stream = f
+        with pytest.raises(RuntimeError):
+            eval_(environment, couch_server, 'ls | command_not_found')
+        # environment.output_stream should be reverted to its original state
+        # if anything in the pipe fails
+        assert environment.output_stream is f

--- a/tests/integration/test_repl.py
+++ b/tests/integration/test_repl.py
@@ -16,7 +16,7 @@ def _get_output(environment):
 
 
 def _get_mock_highlight_json(mocker):
-    mock_highlight = mocker.patch('cdbcli.commands.highlight_json')
+    mock_highlight = mocker.patch('cdbcli.commands.highlighters.json')
     mock_highlight.return_value = ''
     return mock_highlight
 

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -1,0 +1,25 @@
+from cdbcli.lexer import split_cli_command_and_shell_commands
+
+
+def test_split_cli_command_no_shell_commands():
+    cli_command, shell_commands = split_cli_command_and_shell_commands('cat foobar')
+    assert cli_command == 'cat foobar'
+    assert shell_commands == []
+
+
+def test_split_cli_command_and_one_shell_command():
+    cli_command, shell_commands = split_cli_command_and_shell_commands('cat foobar | grep ID')
+    assert cli_command == 'cat foobar'
+    assert shell_commands == ['grep ID']
+
+
+def test_split_cli_command_and_multiple_shell_commands():
+    cli_command, shell_commands = split_cli_command_and_shell_commands('cat foobar | grep ID | uniq | sort')
+    assert cli_command == 'cat foobar'
+    assert shell_commands == ['grep ID', 'uniq', 'sort']
+
+
+def test_split_cli_command_and_multiple_shell_commands_with_space_in_quotes():
+    cli_command, shell_commands = split_cli_command_and_shell_commands('cat foobar | grep ID | cut -d " " -f 2')
+    assert cli_command == 'cat foobar'
+    assert shell_commands == ['grep ID', "cut -d ' ' -f 2"]

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -22,4 +22,4 @@ def test_split_cli_command_and_multiple_shell_commands():
 def test_split_cli_command_and_multiple_shell_commands_with_space_in_quotes():
     cli_command, shell_commands = split_cli_command_and_shell_commands('cat foobar | grep ID | cut -d " " -f 2')
     assert cli_command == 'cat foobar'
-    assert shell_commands == [['grep', 'ID'], ['cut', '-d', "' '", '-f', '2']]
+    assert shell_commands == [['grep', 'ID'], ['cut', '-d', ' ', '-f', '2']]

--- a/tests/unit/test_lexer.py
+++ b/tests/unit/test_lexer.py
@@ -10,16 +10,16 @@ def test_split_cli_command_no_shell_commands():
 def test_split_cli_command_and_one_shell_command():
     cli_command, shell_commands = split_cli_command_and_shell_commands('cat foobar | grep ID')
     assert cli_command == 'cat foobar'
-    assert shell_commands == ['grep ID']
+    assert shell_commands == [['grep', 'ID']]
 
 
 def test_split_cli_command_and_multiple_shell_commands():
     cli_command, shell_commands = split_cli_command_and_shell_commands('cat foobar | grep ID | uniq | sort')
     assert cli_command == 'cat foobar'
-    assert shell_commands == ['grep ID', 'uniq', 'sort']
+    assert shell_commands == [['grep', 'ID'], ['uniq'], ['sort']]
 
 
 def test_split_cli_command_and_multiple_shell_commands_with_space_in_quotes():
     cli_command, shell_commands = split_cli_command_and_shell_commands('cat foobar | grep ID | cut -d " " -f 2')
     assert cli_command == 'cat foobar'
-    assert shell_commands == ['grep ID', "cut -d ' ' -f 2"]
+    assert shell_commands == [['grep', 'ID'], ['cut', '-d', "' '", '-f', '2']]


### PR DESCRIPTION
This allows piping as you would expect in the shell world, e.g.,

```
ls | grep 'd' | cut -d' ' -f2 | uniq | sort
```

See this test for a practical usage: https://github.com/kevinjqiu/cdbcli/pull/32/files#diff-1a0795ae25a9317862c3002303f06a17R394
